### PR TITLE
msg: full refactor & more, see full notes; enh: only a single node cl…

### DIFF
--- a/grafo/trees/__init__.py
+++ b/grafo/trees/__init__.py
@@ -1,4 +1,4 @@
-from .components import Node, PickerNode, UnionNode
+from .components import Node
 from .executor import AsyncTreeExecutor
 
-__all__ = ["Node", "PickerNode", "AsyncTreeExecutor", "UnionNode"]
+__all__ = ["Node", "AsyncTreeExecutor"]

--- a/grafo/trees/components.py
+++ b/grafo/trees/components.py
@@ -1,9 +1,15 @@
-import inspect
-from typing import Any, Callable, Optional, Self, Type
+from typing import Any, Callable, Optional, Self
 
 import asyncio
+from uuid import uuid4
 
 from grafo._internal import logger
+
+
+class SafeExecutionError(Exception):
+    """
+    Exception raised when a method is called on a running node.
+    """
 
 
 def safe_execution(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -14,7 +20,9 @@ def safe_execution(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(self: "Node", *args: Any, **kwargs: Any) -> Any:
         if not self._is_running:
             return func(self, *args, **kwargs)
-        # NOTE: on ELSE, error is not raised so as to not trigger branch/tree cutoff
+        raise SafeExecutionError(
+            f"Skipped <{func.__name__}> call because {self} is running."
+        )  # NOTE: this error will stop the entire process
 
     return wrapper
 
@@ -23,523 +31,135 @@ class Node:
     """
     A Node is a unit of work that can be executed concurrently. It contains a coroutine function that is executed by a worker.
 
-    :param uuid: The unique identifier of the node.
-    :param metadata: A dict containing at least "name" and "description" for the node.
     :param coroutine: The coroutine function to execute.
-    :param args: The arguments to pass to the coroutine.
-    :param kwargs: The keyword arguments to pass to the coroutine.
-    :param children: The children nodes of this node.
-    :param forward_output: Whether to forward the output of this node to its children as arguments.
+    :param kwargs: Optional; the keyword arguments to pass to the coroutine.
+    :param uuid: The unique identifier of the node.
+    :param metadata: Optional; a dict containing at least "name" and "description" for the node.
+    :param timeout: Optional; the timeout for the node. If not provided, a warning will be logged.
 
-    Additionally, the following optional event callback parameters can be passed to the constructor:
+    Additionally, the following optional event callback parameters can be provided as a tuple:
+      (callback, fixed_kwargs)
+    where fixed_kwargs is an optional dict of fixed keyword arguments (defaulting to an empty dict if not provided).
 
-    :param on_connect: Optional; a callback triggered when the `connect()` method is called.
-                       The callback receives the connected child as `child_`.
-    :param on_connect_kwargs: Optional; additional fixed keyword arguments for the `on_connect` callback.
+    :param on_connect: Optional; a tuple (callback, fixed_kwargs) triggered when `connect()` is called.
+    :param on_disconnect: Optional; a tuple (callback, fixed_kwargs) triggered when `disconnect()` is called.
+    :param on_before_run: Optional; a tuple (callback, fixed_kwargs) triggered before the node's coroutine is executed via `run()`.
+    :param on_after_run: Optional; a tuple (callback, fixed_kwargs) triggered after the node's coroutine is executed via `run()`.
 
-    :param on_disconnect: Optional; a callback triggered when the `disconnect()` method is called.
-                          The callback receives the disconnected child as `child_`.
-    :param on_disconnect_kwargs: Optional; additional fixed keyword arguments for the `on_disconnect` callback.
-
-    :param on_update: Optional; a callback triggered when the `update()` method is called.
-                      The callback receives the update parameters with an underscore appended:
-                      `metadata_`, `children_`, `coroutine_`, `args_`, and `kwargs_`.
-    :param on_update_kwargs: Optional; additional fixed keyword arguments for the `on_update` callback.
-
-    :param on_before_run: Optional; a callback triggered before the node's coroutine is executed via `run()`.
-                          No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_before_run_kwargs: Optional; additional fixed keyword arguments for the `on_before_run` callback.
-
-    :param on_after_run: Optional; a callback triggered after the node's coroutine is executed via `run()`.
-                         No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_after_run_kwargs: Optional; additional fixed keyword arguments for the `on_after_run` callback.
-
-    **Note:** For each event callback in Node, if an associated function passes a parameter named `param`,
-            the callback will receive that parameter as `param_`. For example, in `set_output(output)`,
-            the callback is invoked with `output_=output`.
+    **Important:** All coroutines and callbacks are automatically called with the node instance (self) as the first (positional) argument.
     """
-
-    _output: Any
 
     def __init__(
         self,
-        uuid: str,
-        metadata: dict,
         coroutine: Callable,
-        args: Optional[list[Any]] = None,
         kwargs: Optional[dict[str, Any]] = None,
-        forward_output: Optional[bool] = False,
-        on_connect: Optional[Callable[..., Any]] = None,
-        on_connect_kwargs: Optional[dict[str, Any]] = None,
-        on_disconnect: Optional[Callable[..., Any]] = None,
-        on_disconnect_kwargs: Optional[dict[str, Any]] = None,
-        on_update: Optional[Callable[..., Any]] = None,
-        on_update_kwargs: Optional[dict[str, Any]] = None,
-        on_before_run: Optional[Callable[..., Any]] = None,
-        on_before_run_kwargs: Optional[dict[str, Any]] = None,
-        on_after_run: Optional[Callable[..., Any]] = None,
-        on_after_run_kwargs: Optional[dict[str, Any]] = None,
-    ):
-        self.__validate_param(uuid, "uuid", str)
-        self.__validate_param(args, "args", list, allow_none=True)
-        self.__validate_param(kwargs, "kwargs", dict, allow_none=True)
-        self._metadata = metadata
-
-        if not inspect.iscoroutinefunction(coroutine):
-            raise ValueError(
-                "The coroutine parameter must be a coroutine function (async function)."
-            )
-
-        self._uuid = uuid
-        self._coroutine = coroutine
-        self._args = args if args is not None else []
-        self._kwargs = kwargs if kwargs is not None else {}
-        self._output = None
-        self._children = []
-        self._is_running = False
-        self._forward_output = forward_output
-        self._event = asyncio.Event()
-
-        self._on_connect_callback = (
-            (on_connect, on_connect_kwargs or {}) if on_connect is not None else None
-        )
-        self._on_disconnect_callback = (
-            (on_disconnect, on_disconnect_kwargs or {})
-            if on_disconnect is not None
-            else None
-        )
-        self._on_update_callback = (
-            (on_update, on_update_kwargs or {}) if on_update is not None else None
-        )
-        self._on_before_run_callback = (
-            (on_before_run, on_before_run_kwargs or {})
-            if on_before_run is not None
-            else None
-        )
-        self._on_after_run_callback = (
-            (on_after_run, on_after_run_kwargs or {})
-            if on_after_run is not None
-            else None
-        )
-
-    def __repr__(self) -> str:
-        return f"Node(uuid={self.uuid}, metadata={self.metadata}, output={self.output})"
-
-    @property
-    def uuid(self):
-        return self._uuid
-
-    @property
-    def metadata(self):
-        return self._metadata
-
-    @property
-    def children(self):
-        return self._children
-
-    @property
-    def coroutine(self):
-        return self._coroutine
-
-    @property
-    def args(self):
-        return self._args
-
-    @property
-    def kwargs(self):
-        return self._kwargs
-
-    @property
-    def output(self):
-        return self._output
-
-    def __validate_param(
-        self, param: Any, param_name: str, expected_type: Type, allow_none: bool = False
-    ):
-        """
-        Validates that a parameter is of the expected type.
-
-        :param param: The parameter to validate.
-        :param param_name: The name of the parameter (used in the error message).
-        :param expected_type: The expected type of the parameter.
-        :param allow_none: Whether None is allowed as a valid value.
-        """
-        if param is None and allow_none:
-            return
-
-        if not isinstance(param, expected_type):
-            raise ValueError(
-                f"'{param_name}' is required and must be of type {expected_type.__name__}."
-            )
-
-    def _run_event(self, callback: Callable, *args: Any, **kwargs: Any):
-        """
-        Executes an event callback which can be either synchronous or asynchronous.
-        It checks whether we're in an async context (i.e. if there is a current task)
-        and returns an awaitable if so; otherwise it runs the callback completely.
-
-        If in an async context and the callback is synchronous, its result is wrapped
-        as an awaitable via a zero-second asyncio.sleep call.
-        """
-        in_async = asyncio.current_task() is not None
-        if inspect.iscoroutinefunction(callback):
-            coro = callback(*args, **kwargs)
-            if in_async:
-                # In an async context, return the coroutine so the caller can await it.
-                return coro
-            else:
-                try:
-                    loop = asyncio.get_running_loop()
-                except RuntimeError:
-                    # No running loop; run the coroutine to completion.
-                    return asyncio.run(coro)
-                else:
-                    return loop.run_until_complete(coro)
-        else:
-            result = callback(*args, **kwargs)
-            if in_async:
-                # Wrap synchronous result as an awaitable (immediately available).
-                return asyncio.sleep(0, result=result)
-            else:
-                return result
-
-    @safe_execution
-    def connect(self, child: Self):
-        """
-        Connects a child to this node.
-        """
-        if not issubclass(type(child), Node):
-            raise ValueError("The 'child' parameter must be a Node instance.")
-        if isinstance(child, UnionNode) and isinstance(self, PickerNode):
-            raise ValueError(
-                "A UnionNode cannot have a PickerNode as a child. Use a PickerNode as a parent instead."
-            )
-        self.children.append(child)
-        if isinstance(child, UnionNode):
-            child._add_event(self._event)
-        if self._on_connect_callback:
-            callback, fixed_kwargs = self._on_connect_callback
-            self._run_event(callback, child_=child, **fixed_kwargs)
-
-    @safe_execution
-    def disconnect(self, child: Self):
-        """
-        Disconnects a child from this node.
-        """
-        if not issubclass(type(child), Node):
-            raise ValueError("The 'child' parameter must be a Node instance.")
-        self.children.remove(child)
-        if isinstance(child, UnionNode):
-            child._remove_event(self._event)
-        if self._on_disconnect_callback:
-            callback, fixed_kwargs = self._on_disconnect_callback
-            self._run_event(callback, child_=child, **fixed_kwargs)
-
-    @safe_execution
-    def update(
-        self,
+        uuid: Optional[str] = None,
         metadata: Optional[dict] = None,
-        children: Optional[list[Self]] = None,
-        coroutine: Optional[Callable] = None,
-        args: Optional[list[Any]] = None,
-        kwargs: Optional[dict[str, Any]] = None,
-        append_mode: bool = False,
+        timeout: Optional[float] = 60.0,
+        on_connect: Optional[
+            tuple[Callable[..., Any], Optional[dict[str, Any]]]
+        ] = None,
+        on_disconnect: Optional[
+            tuple[Callable[..., Any], Optional[dict[str, Any]]]
+        ] = None,
+        on_before_run: Optional[
+            tuple[Callable[..., Any], Optional[dict[str, Any]]]
+        ] = None,
+        on_after_run: Optional[
+            tuple[Callable[..., Any], Optional[dict[str, Any]]]
+        ] = None,
     ):
-        """
-        Updates the node with new data.
-
-        :param metadata: Optional; a dict containing the node's metadata.
-        :param children: Optional; a list of children nodes.
-        :param coroutine: Optional; a coroutine function to execute.
-        :param args: Optional; a list of arguments to pass to the coroutine.
-        :param kwargs: Optional; a dict of keyword arguments to pass to the coroutine.
-        :param append_mode: Optional; if True, the args and kwargs will be appended to the existing data.
-        """
-
-        if metadata is not None:
-            self._metadata = metadata
-
-        if children is not None:
-            self._children = children
-
-        if coroutine is not None:
-            if not inspect.iscoroutinefunction(coroutine):
-                raise ValueError(
-                    "The 'coroutine' parameter must be a coroutine function (async function)."
-                )
-            self._coroutine = coroutine
-
-        self.__validate_param(args, "args", list, allow_none=True)
-        self.__validate_param(kwargs, "kwargs", dict, allow_none=True)
-
-        if append_mode:
-            if args:
-                self._args.extend(args)
-            if kwargs:
-                self._kwargs.update(kwargs)
-        else:
-            self._args = args if args is not None else []
-            self._kwargs = kwargs if kwargs is not None else {}
-
-        if self._on_update_callback:
-            callback, fixed_kwargs = self._on_update_callback
-            self._run_event(callback, children_=children, **fixed_kwargs)
-
-    @safe_execution
-    async def run(self) -> Any:
-        """
-        Asynchronously runs the coroutine of in this node.
-        """
-        logger.debug(f"Running {self}")
-        if self._on_before_run_callback:
-            callback, fixed_kwargs = self._on_before_run_callback
-            # In an async context, await the event callback.
-            await self._run_event(callback, **fixed_kwargs)
-
-        try:
-            self._is_running = True
-            result = await self._coroutine(*self.args, **self.kwargs)
-            self._output = result
-            self._event.set()
-            return result
-        finally:
-            if self._on_after_run_callback:
-                callback, fixed_kwargs = self._on_after_run_callback
-                # Await the after-run event callback.
-                await self._run_event(callback, output_=result, **fixed_kwargs)
-            self._is_running = False
-
-
-class PickerNode(Node):
-    """
-    A node that uses an LLM to determine which children to queue next.
-
-    :param uuid: The unique identifier of the node.
-    :param metadata: A dict containing at least "name" and "description" for the node.
-    :param coroutine: The coroutine (picker) function to execute.
-    :param args: The arguments to pass to the coroutine.
-    :param kwargs: The keyword arguments to pass to the coroutine.
-    :param children: The children nodes of this node.
-    :param forward_output: Whether to forward the output of this node to its children as arguments.
-
-    Additionally, the following optional event callback parameters can be passed to the constructor:
-
-    :param on_connect: Optional; a callback triggered when the `connect()` method is called.
-                       The callback receives the connected child as `child_`.
-    :param on_connect_kwargs: Optional; additional fixed keyword arguments for the `on_connect` callback.
-
-    :param on_disconnect: Optional; a callback triggered when the `disconnect()` method is called.
-                          The callback receives the disconnected child as `child_`.
-    :param on_disconnect_kwargs: Optional; additional fixed keyword arguments for the `on_disconnect` callback.
-
-    :param on_update: Optional; a callback triggered when the `update()` method is called.
-                      The callback receives the update parameters with an underscore appended:
-                      `metadata_`, `children_`, `coroutine_`, `args_`, and `kwargs_`.
-    :param on_update_kwargs: Optional; additional fixed keyword arguments for the `on_update` callback.
-
-    :param on_before_run: Optional; a callback triggered before the node's coroutine is executed via `run()`.
-                          No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_before_run_kwargs: Optional; additional fixed keyword arguments for the `on_before_run` callback.
-
-    :param on_after_run: Optional; a callback triggered after the node's coroutine is executed via `run()`.
-                         No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_after_run_kwargs: Optional; additional fixed keyword arguments for the `on_after_run` callback.
-    """
-
-    def __init__(
-        self,
-        uuid: str,
-        metadata: dict,
-        coroutine: Callable,
-        args: Optional[list[Any]] = None,
-        kwargs: Optional[dict[str, Any]] = None,
-        forward_output: Optional[bool] = False,
-        on_connect: Optional[Callable[..., Any]] = None,
-        on_connect_kwargs: Optional[dict[str, Any]] = None,
-        on_disconnect: Optional[Callable[..., Any]] = None,
-        on_disconnect_kwargs: Optional[dict[str, Any]] = None,
-        on_update: Optional[Callable[..., Any]] = None,
-        on_update_kwargs: Optional[dict[str, Any]] = None,
-        on_before_run: Optional[Callable[..., Any]] = None,
-        on_before_run_kwargs: Optional[dict[str, Any]] = None,
-        on_after_run: Optional[Callable[..., Any]] = None,
-        on_after_run_kwargs: Optional[dict[str, Any]] = None,
-    ):
-        super().__init__(
-            uuid,
-            metadata,
-            coroutine,
-            args,
-            kwargs,
-            forward_output,
-            on_connect=on_connect,
-            on_connect_kwargs=on_connect_kwargs,
-            on_disconnect=on_disconnect,
-            on_disconnect_kwargs=on_disconnect_kwargs,
-            on_update=on_update,
-            on_update_kwargs=on_update_kwargs,
-            on_before_run=on_before_run,
-            on_before_run_kwargs=on_before_run_kwargs,
-            on_after_run=on_after_run,
-            on_after_run_kwargs=on_after_run_kwargs,
-        )
-
-    def __repr__(self) -> str:
-        return f"PickerNode(uuid={self.uuid}, metadata={self.metadata}, output={self.output})"
-
-    @safe_execution
-    async def run(self) -> list["Node"]:
-        """
-        Picks the children to queue next based on the result of the node.
-        """
-        if self._on_before_run_callback:
-            callback, fixed_kwargs = self._on_before_run_callback
-            # Await the before-run callback via _run_event.
-            await self._run_event(callback, **fixed_kwargs)
-
-        try:
-            self._is_running = True
-            result = await self.coroutine(
-                self, self.children, *self.args, **self.kwargs
+        if not timeout:
+            logger.warning(
+                "Node %s has no timeout, which can cause trees to run indefinitely. Consider setting a timeout.",
+                self.uuid,
             )
-            if not isinstance(result, list):
-                raise ValueError("The picker coroutine must return a list of children.")
-            for child in result:
-                if not isinstance(child, Node):
-                    raise ValueError(
-                        "The picker coroutine must return a list of Node instances."
-                    )
-            self._output = result
-            return result
-        finally:
-            if self._on_after_run_callback:
-                callback, fixed_kwargs = self._on_after_run_callback
-                # Await the after-run callback via _run_event.
-                await self._run_event(callback, output_=result, **fixed_kwargs)
-            self._is_running = False
 
+        self.coroutine: Callable = coroutine
+        self.kwargs: dict[str, Any] = kwargs if kwargs is not None else {}
+        self.uuid: str = uuid or str(uuid4())
+        self.metadata: Optional[dict] = metadata
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+        self.on_before_run = on_before_run
+        self.on_after_run = on_after_run
 
-class UnionNode(Node):
-    """
-    A node that waits for all its parents to finish executing before continuing.
+        self.children: list["Node"] = []
+        self.output: Any = None
+        self.event: asyncio.Event = asyncio.Event()
 
-    :param uuid: The unique identifier of the node.
-    :param metadata: A dict containing at least "name" and "description" for the node.
-    :param coroutine: The coroutine function to execute.
-    :param args: The arguments to pass to the coroutine.
-    :param kwargs: The keyword arguments to pass to the coroutine.
-    :param parent_events: The events to wait for from the parent nodes.
-    :param timeout: The timeout for waiting for parents to complete.
-    :param forward_output: Whether to forward the output of this node to its children as arguments.
-
-    Additionally, the following optional event callback parameters can be passed to the constructor:
-
-    :param on_connect: Optional; a callback triggered when the `connect()` method is called.
-                       The callback receives the connected child as `child_`.
-    :param on_connect_kwargs: Optional; additional fixed keyword arguments for the `on_connect` callback.
-
-    :param on_disconnect: Optional; a callback triggered when the `disconnect()` method is called.
-                          The callback receives the disconnected child as `child_`.
-    :param on_disconnect_kwargs: Optional; additional fixed keyword arguments for the `on_disconnect` callback.
-
-    :param on_update: Optional; a callback triggered when the `update()` method is called.
-                      The callback receives the update parameters with an underscore appended:
-                      `metadata_`, `children_`, `coroutine_`, `args_`, and `kwargs_`.
-    :param on_update_kwargs: Optional; additional fixed keyword arguments for the `on_update` callback.
-
-    :param on_before_run: Optional; a callback triggered before the node's coroutine is executed via `run()`.
-                          No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_before_run_kwargs: Optional; additional fixed keyword arguments for the `on_before_run` callback.
-
-    :param on_after_run: Optional; a callback triggered after the node's coroutine is executed via `run()`.
-                         No additional timed parameters are provided, but fixed kwargs can be passed.
-    :param on_after_run_kwargs: Optional; additional fixed keyword arguments for the `on_after_run` callback.
-
-    NOTE: USE WITH CARE! This node can cause deadlocks if not used properly.
-    """
-
-    def __init__(
-        self,
-        uuid: str,
-        metadata: dict,
-        coroutine: Callable,
-        args: Optional[list[Any]] = None,
-        kwargs: Optional[dict[str, Any]] = None,
-        parent_events: Optional[list[asyncio.Event]] = None,
-        timeout: Optional[float] = None,
-        forward_output: Optional[bool] = False,
-        on_connect: Optional[Callable[..., Any]] = None,
-        on_connect_kwargs: Optional[dict[str, Any]] = None,
-        on_disconnect: Optional[Callable[..., Any]] = None,
-        on_disconnect_kwargs: Optional[dict[str, Any]] = None,
-        on_update: Optional[Callable[..., Any]] = None,
-        on_update_kwargs: Optional[dict[str, Any]] = None,
-        on_before_run: Optional[Callable[..., Any]] = None,
-        on_before_run_kwargs: Optional[dict[str, Any]] = None,
-        on_after_run: Optional[Callable[..., Any]] = None,
-        on_after_run_kwargs: Optional[dict[str, Any]] = None,
-    ):
-        super().__init__(
-            uuid,
-            metadata,
-            coroutine,
-            args,
-            kwargs,
-            forward_output=forward_output,
-            on_connect=on_connect,
-            on_connect_kwargs=on_connect_kwargs,
-            on_disconnect=on_disconnect,
-            on_disconnect_kwargs=on_disconnect_kwargs,
-            on_update=on_update,
-            on_update_kwargs=on_update_kwargs,
-            on_before_run=on_before_run,
-            on_before_run_kwargs=on_before_run_kwargs,
-            on_after_run=on_after_run,
-            on_after_run_kwargs=on_after_run_kwargs,
-        )
-        self._parent_events = parent_events if parent_events is not None else []
-        self._forward_output = forward_output
-        self._timeout = timeout
+        # * Inner flags
+        self._is_running: bool = False
+        self._parent_events: list[asyncio.Event] = []
+        self._timeout: Optional[float] = timeout
 
     def __repr__(self) -> str:
-        return f"UnionNode(uuid={self.uuid}, metadata={self.metadata}, timeout={self._timeout}, output={self.output})"
+        return f"Node(uuid={self.uuid})"
 
-    @property
-    def parent_events(self):
-        return self._parent_events
+    def __setattr__(self, name: str, value: Any) -> None:
+        # ? REASON: check if _is_running exists to avoid interfering during __init__
+        if (
+            name not in ["_is_running", "output"]
+            and hasattr(self, "_is_running")
+            and self._is_running
+        ):
+            raise SafeExecutionError(
+                f"Cannot change property '{name}' while the node is running."
+            )
+        super().__setattr__(name, value)
 
-    @safe_execution
     def _add_event(self, event: asyncio.Event):
         """
         Adds an event to this node so that it waits for it to be set before running.
         """
         self._parent_events.append(event)
 
-    @safe_execution
     def _remove_event(self, event: asyncio.Event):
         """
         Removes an event from this node so that it no longer waits for it to be set before running.
         """
         self._parent_events.remove(event)
 
+    def connect(self, child: Self):
+        """
+        Connects a child to this node.
+        """
+        self.children.append(child)
+        child._add_event(self.event)
+        if self.on_connect:
+            callback, fixed_kwargs = self.on_connect
+            callback(self, **(fixed_kwargs or {}))
+
+    def disconnect(self, child: Self):
+        """
+        Disconnects a child from this node.
+        """
+        self.children.remove(child)
+        child._remove_event(self.event)
+        if self.on_disconnect:
+            callback, fixed_kwargs = self.on_disconnect
+            callback(self, **(fixed_kwargs or {}))
+
     @safe_execution
     async def run(self) -> Any:
         """
-        Waits for all parents to complete before running the coroutine.
+        Asynchronously runs the coroutine of in this node.
         """
-        if not self._timeout:
-            logger.warning(
-                "UnionNode %s has no timeout. This will cause a deadlock if one of its parent coroutines does not finish.",
-                self.uuid,
-            )
-        logger.debug(f"Number of events to wait for: {len(self.parent_events)}")
         await asyncio.wait_for(
-            asyncio.gather(*[e.wait() for e in self.parent_events]),
+            asyncio.gather(*[e.wait() for e in self._parent_events]),
             timeout=self._timeout,
         )
 
+        if self.on_before_run:
+            callback, fixed_kwargs = self.on_before_run
+            callback(self, **(fixed_kwargs or {}))
+
         try:
-            return await super().run()
-        except Exception as e:
-            self._children = []
-            raise e
+            self._is_running = True
+            self.output = await self.coroutine(self, **self.kwargs)
+            self.event.set()
+        finally:
+            self._is_running = False
+            if self.on_after_run:
+                callback, fixed_kwargs = self.on_after_run
+                callback(self, **(fixed_kwargs or {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grafo"
-version = "0.1.403"
+version = "0.2.000"
 description = "A library for building runnable asynchronous trees"
 readme = "readme.md"
 authors = [

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,20 @@
 ## What ##
-A simple library for building runnable tree structures. Trees are built using Nodes, which
-contain code to be run. The number of workers is automatically managed (optional).
+A simple library for building runnable async trees. Trees are a web of interconnected Nodes, which contain code to be run. The number of workers is automatically managed (optional).
 
 Use:
 
 ```
 # Declare your nodes
 root_node = Node(...)
-child_node1 = Node(...)
-child_node2 = Node(...)
-grandchild_node1 = Node(...)
+child1 = Node(...)
+child2 = Node(...)
+grandchild = Node(...)
 
 # Set the layout
 nodes = {
     root_node: {
-        child_node1: None,
-        child_node2: [grandchild_node1],
+        child1: [grandchild],
+        child2: [grandchild], # grandchild_node will wait for child1 and child2 to complete before running
     }
 }
 
@@ -30,19 +29,22 @@ Powered by `asyncio` (https://docs.python.org/3/library/asyncio.html)
 ## How ##
 - You have a tree of interconected `Nodes` and an `asyncio.Queue()`
 - Upon each Node's execution, it removes itself from the queue and enqueues its children up next
-- ⚠️ Be careful with UnionNodes, they can cause invisible deadlocks. ⚠️
 
 ## Axioms ##
-1) A tree can only have one root node.
-2) Nodes can be run concurrently.
-3) Dictionary outputs are passed as kwargs to children. All other types are passed as args.
-4) UnionNodes can never be direct children of PickerNodes.
+1) A tree must include a designated root node, and there can be only one unique root.
+2) Children start running as soon as all their parent's are finished.
+3) There's no passing of state between nodes - you can handle that however you see fit
+
+## Important ##
+- Node properties are generally accessible, but are immutable during a node's runtime (do not confuse with the tree's runtime).
+- Coroutines and callbacks will always receive the `node` as their first (positional) argument. Everything else if a `keyword argument`.
+- `on_before_run` and `on_after_run` callbacks must be asynchronous
+
+## Installation ##
+- `pip install grafo` to install on your environment
+- `pytest` to run tests, add `-s` flag for tests to run `print` statements
 
 ## Zen ##
 1. Follow established names: a Node is a Node, not a "Leaf".
 2. Syntax sugar is sweet in moderation.
 3. Give the programmer granular control.
-
-## During Development ##
-- `pip install grafo` to install on your environment
-- `pytest` to run tests, add `-s` flag for tests to run `print` statements

--- a/tests/test_async_tree.py
+++ b/tests/test_async_tree.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
 import pytest
 
-from grafo.trees import AsyncTreeExecutor, Node, PickerNode, UnionNode
+from grafo.trees import AsyncTreeExecutor, Node
 from grafo._internal import logger
 
 logger.setLevel(logging.DEBUG)
@@ -15,71 +15,46 @@ logger.setLevel(logging.DEBUG)
 def create_node(
     name: str,
     coroutine: Any,
-    picker: Optional[Any] = None,
-    is_union_node: bool = False,
     timeout: Optional[float] = None,
     on_after_run: Optional[Callable[..., Any]] = None,
     on_after_run_kwargs: Optional[dict[str, Any]] = None,
-) -> Union[PickerNode, UnionNode, Node]:
+) -> Node:
     """
     Create a node with the given name, coroutine, and picker function.
     """
     metadata = {"name": name, "description": f"{name.capitalize()} Node"}
-    if picker:
-        return PickerNode(
-            uuid=str(uuid4()),
-            metadata=metadata,
-            args=[name],
-            coroutine=picker,
-            # forward_output=True,
-        )
-    if is_union_node:
-        node = UnionNode(
-            uuid=str(uuid4()),
-            metadata=metadata,
-            coroutine=coroutine,
-            args=[name],
-            timeout=timeout,
-            # forward_output=True,
-            on_after_run=on_after_run,
-            on_after_run_kwargs=on_after_run_kwargs,
-        )
-        return node
-
     return Node(
         uuid=str(uuid4()),
         metadata=metadata,
         coroutine=coroutine,
-        args=[name],
-        # forward_output=True,
+        timeout=timeout,
+        on_after_run=(on_after_run, on_after_run_kwargs) if on_after_run else None,
     )
 
 
-async def mockup_coroutine(name):
+async def mockup_coroutine(node: Node):
     """
     Example coroutine function that simulates a task that takes 1 second to complete.
     """
     await asyncio.sleep(1)
-    # logger.debug(f"{name} executed")
-    return f"{name} result"
+    return f"{(node.metadata or {}).get('name')} result"
 
 
-async def mockup_bad_coroutine(name):
-    """
-    Example coroutine function that simulates an error.
-    """
-    raise ValueError(f"{name} failed!")
-
-
-async def mockup_picker(node: Node, children: List[Node], *args) -> List[Node]:
+async def mockup_picker(node: Node):
     """
     Example picker function that selects the first and third children of the root node.
     """
-    logger.debug(f"{node.metadata['name']} executed")
     logger.debug(
-        f"  -> picked: {children[0].metadata['name']}, {children[2].metadata['name']}"
+        f"  -> picked: {(node.children[0].metadata or {}).get('name')}, {(node.children[2].metadata or {}).get('name')}"
     )
-    return [children[0], children[2]]
+    node.disconnect(node.children[1])
+
+
+async def mockup_bad_coroutine(_):
+    """
+    Example coroutine function that simulates an error.
+    """
+    raise ValueError("bad coroutine")
 
 
 # Tests
@@ -98,7 +73,7 @@ async def test_manual_tree():
     child_node1.connect(grandchild_node1)
     child_node1.connect(grandchild_node2)
 
-    executor = AsyncTreeExecutor(name="Manual Tree", root=root_node, num_workers=3)
+    executor = AsyncTreeExecutor(uuid="Manual Tree", root=root_node, num_workers=3)
     result = await executor.run()
 
     # Assert result
@@ -113,11 +88,11 @@ async def test_manual_tree():
 
 
 @pytest.mark.asyncio
-async def test_with_picker_node():
+async def test_picker():
     """
     Test the AsyncTreeExecutor using a JSON-like structure to build the tree.
     """
-    root_node = create_node("root", None, mockup_picker)
+    root_node = create_node("root", mockup_picker)
     child_node1 = create_node("child1", mockup_coroutine)
     child_node2 = create_node("child2", mockup_coroutine)
     child_node3 = create_node("child3", mockup_coroutine)
@@ -134,7 +109,7 @@ async def test_with_picker_node():
     }
 
     # Forward the results of each node to its children as arguments
-    executor = AsyncTreeExecutor(name="Picker Tree")
+    executor = AsyncTreeExecutor(uuid="Picker Tree")
     tree = executor | nodes
     result = await tree.run()
 
@@ -151,7 +126,7 @@ async def test_with_picker_node():
 
 
 @pytest.mark.asyncio
-async def test_with_union_node():
+async def test_union():
     """
     Test the AsyncTreeExecutor using a JSON-like structure to build the tree with a UnionNode.
     """
@@ -159,7 +134,7 @@ async def test_with_union_node():
     child_node1 = create_node("child1", mockup_coroutine)
     child_node2 = create_node("child2", mockup_coroutine)
     child_node3 = create_node("child3", mockup_coroutine)
-    grandchild_node1 = create_node("grandchild1", mockup_coroutine, is_union_node=True)
+    grandchild_node1 = create_node("grandchild1", mockup_coroutine)
     grandchild_node2 = create_node("grandchild2", mockup_coroutine)
 
     # Using a JSON-like structure and the '|' operator to build the tree
@@ -173,7 +148,7 @@ async def test_with_union_node():
 
     # Forward the results of each node to its children as arguments
     executor = AsyncTreeExecutor(
-        name="Union Tree", use_dynamic_workers=False, num_workers=10
+        uuid="Union Tree", use_dynamic_workers=False, num_workers=10
     )
     tree = executor | nodes
     result = await tree.run()
@@ -192,37 +167,7 @@ async def test_with_union_node():
 
 
 @pytest.mark.asyncio
-async def test_error_cutoff_branch():
-    """
-    Test the AsyncTreeExecutor using a JSON-like structure to build the tree with a UnionNode.
-    """
-    root_node = create_node("root", mockup_coroutine)
-    child_node1 = create_node("child1", mockup_coroutine)
-    child_node2 = create_node("child2", mockup_bad_coroutine)
-    grandchild_node1 = create_node("grandchild1", mockup_bad_coroutine)
-
-    # Using a JSON-like structure and the '|' operator to build the tree
-    nodes = {
-        root_node: {
-            child_node1: None,
-            child_node2: [grandchild_node1],
-        }
-    }
-
-    # Forward the results of each node to its children as arguments
-    executor = AsyncTreeExecutor(cutoff_branch_on_error=True)
-    tree = executor | nodes
-    result = await tree.run()
-
-    # Assert result
-    nodes_uuids = [root_node.uuid, child_node1.uuid]
-    assert all(node.uuid in nodes_uuids for node in result)
-    assert child_node2.uuid not in nodes_uuids
-    logger.debug(result)
-
-
-@pytest.mark.asyncio
-async def test_error_quit_tree():
+async def test_error():
     """
     Test the AsyncTreeExecutor using a JSON-like structure to build the tree with a UnionNode.
     """
@@ -241,7 +186,7 @@ async def test_error_quit_tree():
     }
 
     # Forward the results of each node to its children as arguments
-    executor = AsyncTreeExecutor(quit_tree_on_error=True)
+    executor = AsyncTreeExecutor(uuid="Error Tree")
     tree = executor | nodes
     result = await tree.run()
 
@@ -253,47 +198,7 @@ async def test_error_quit_tree():
 
 
 @pytest.mark.asyncio
-async def test_union_node_timeout():
-    """
-    Test the AsyncTreeExecutor with a UnionNode that has a timeout.
-    """
-
-    async def long_running_coroutine(name):
-        # Simulate a long-running task
-        await asyncio.sleep(3)
-        logger.debug(f"{name} executed")
-        return f"{name} result"
-
-    root_node = create_node("root", mockup_coroutine)
-    child_node1 = create_node("child1", long_running_coroutine)
-    child_node2 = create_node("child2", mockup_coroutine)
-    # Create a UnionNode with a timeout of 1 second
-    union_node: UnionNode = create_node(
-        "union", mockup_coroutine, is_union_node=True, timeout=1
-    )  # type: ignore
-
-    # Using a JSON-like structure and the '|' operator to build the tree
-    nodes = {
-        root_node: {
-            child_node1: [union_node],
-            child_node2: [union_node],
-        }
-    }
-
-    # Forward the results of each node to its children as arguments
-    executor = AsyncTreeExecutor(quit_tree_on_error=True)
-    tree = executor | nodes
-    result = await tree.run()
-
-    # Assert that the root and child nodes completed successfully
-    nodes_uuids = [root_node.uuid, child_node1.uuid]
-    assert all(node.uuid in nodes_uuids for node in result)
-    assert union_node.uuid not in nodes_uuids
-    logger.debug(result)
-
-
-@pytest.mark.asyncio
-async def test_run_and_yield():
+async def test_yielding():
     """
     Test the AsyncTreeExecutor's run_and_yield method to ensure it yields results as they are set.
     """
@@ -308,7 +213,7 @@ async def test_run_and_yield():
             child_node1: [grandchild_node1, grandchild_node2],
         }
     }
-    executor = AsyncTreeExecutor(name="Yielding Tree")
+    executor = AsyncTreeExecutor(uuid="Yielding Tree")
     tree = executor | nodes
     results = []
 
@@ -332,52 +237,6 @@ async def test_run_and_yield():
 
 
 @pytest.mark.asyncio
-async def test_run_and_yield_with_union_node():
-    """
-    Test the AsyncTreeExecutor's run_and_yield method with a UnionNode to ensure it yields results from all nodes, including a UnionNode.
-    """
-    root_node = create_node("root", mockup_coroutine)
-    child_node1 = create_node("child1", mockup_coroutine)
-    # Create a UnionNode by setting is_union_node=True
-    union_node = create_node("union", mockup_coroutine, is_union_node=True)
-    child_node2 = create_node("child2", mockup_coroutine)
-    grandchild_node1 = create_node("grandchild1", mockup_coroutine)
-    grandchild_node2 = create_node("grandchild2", mockup_coroutine)
-
-    # Building the tree using a JSON-like structure
-    nodes = {
-        root_node: {
-            child_node1: {union_node: [grandchild_node1, grandchild_node2]},
-            child_node2: [union_node],
-        }
-    }
-
-    executor = AsyncTreeExecutor(name="Yielding Tree with Union")
-    tree = executor | nodes
-    results = []
-
-    stop_event = asyncio.Event()
-    async for node in tree.yielding([stop_event]):
-        results.append((node.uuid, node))
-        logger.debug(f"Yielded: {node}")
-        if node.uuid == grandchild_node2.uuid:
-            stop_event.set()
-
-    expected_node_ids = [
-        root_node.uuid,
-        child_node1.uuid,
-        union_node.uuid,
-        child_node2.uuid,
-        grandchild_node1.uuid,
-        grandchild_node2.uuid,
-    ]
-
-    yielded_ids = [n_uuid for n_uuid, _ in results]
-    assert all(node_uuid in yielded_ids for node_uuid in expected_node_ids)
-    logger.debug("All nodes yielded successfully.")
-
-
-@pytest.mark.asyncio
 async def test_yield_with_timeout():
     """
     Test the AsyncTreeExecutor's yielding method with a UnionNode that times out,
@@ -390,7 +249,7 @@ async def test_yield_with_timeout():
         logger.debug(f"{name} executed")
         return f"{name} result"
 
-    def stop_yielding(stop_event: asyncio.Event, **kwargs):
+    def stop_yielding(stop_event: asyncio.Event):
         stop_event.set()
 
     stop_event = asyncio.Event()
@@ -401,7 +260,6 @@ async def test_yield_with_timeout():
     union_node = create_node(
         "union",
         long_running_coroutine,
-        is_union_node=True,
         timeout=1,
         on_after_run=stop_yielding,
         on_after_run_kwargs={"stop_event": stop_event},
@@ -415,9 +273,7 @@ async def test_yield_with_timeout():
         }
     }
 
-    executor = AsyncTreeExecutor(
-        name="Yielding Tree with Timeout", quit_tree_on_error=True
-    )
+    executor = AsyncTreeExecutor(uuid="Yielding Tree with Timeout")
     tree = executor | nodes
     results = []
 


### PR DESCRIPTION
- Single node type
- Nodes now always wait for all parents to complete
- Manage children during runtime via `.connect()` and `.disconnect()`
- Coroutines and callbacks get injected with `self` as the first positional argument
& more