### PR TITLE
Feat/error capture

### DIFF
--- a/grafo/trees/components.py
+++ b/grafo/trees/components.py
@@ -220,7 +220,6 @@ class Node(Generic[T]):
             runtime_kwargs = self._eval_kwargs(self.kwargs)
             self.output = await self.coroutine(**runtime_kwargs)
             self._event.set()
-
         finally:
             self._is_running = False
             end_time = time.time()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grafo"
-version = "0.2.015"
+version = "0.2.016"
 description = "A library for building runnable asynchronous trees"
 readme = "readme.md"
 authors = [


### PR DESCRIPTION
Error capture during tree execution to allow you to re-raise errors should you wish to do so. Additionally, errors raised during events will stop the entire tree, so beware.